### PR TITLE
Add AI model preloading to prevent freeze on first game start

### DIFF
--- a/GameApp.py
+++ b/GameApp.py
@@ -5,6 +5,7 @@ from views.MainMenuView import MainMenuView
 from views.GameView import GameView
 from views.DeckManagerView import DeckManagerView
 from views.CreditsView import CreditsView
+from views.SplashScreenView import SplashScreenView
 from utils.GameLogger import GameLogger
 from utils.GameResourcesManager import GameResourcesManager
 from Game import Game
@@ -16,6 +17,7 @@ class GameApp(QMainWindow):
         self.game_instance = Game()
         self.config = Config()
         self.game_logger = None
+        self.ai_models: list[str] = []
 
         self.setWindowTitle('Castle Wars')
         self.setFixedSize(int(self.config.window_width), int(self.config.window_height))
@@ -24,7 +26,7 @@ class GameApp(QMainWindow):
         self.setCentralWidget(self.central_widget)
         self.layout = QVBoxLayout(self.central_widget)
 
-        self.current_view = MainMenuView(self, self.start_sp_game, self.start_mp_game, self.start_cpu_game, self.show_deck_manager, self.show_credits)
+        self.current_view = SplashScreenView(self, self._on_splash_done)
         self.layout.addWidget(self.current_view)
         
     def switch_view(self, new_view, *args, **kwargs) -> None:
@@ -78,6 +80,13 @@ class GameApp(QMainWindow):
         self.game_instance.setup_cpu_only(default_player_names, player2_type=RuleBasedAIPlayer)
         self.start_game()
 
+    def _on_splash_done(self, ai_models: list) -> None:
+        self.ai_models = ai_models
+        self.show_main_menu()
+
+    def show_main_menu(self) -> None:
+        self.switch_view(MainMenuView, self.start_sp_game, self.start_mp_game, self.start_cpu_game, self.show_deck_manager, self.show_credits, self.ai_models)
+
     def show_deck_manager(self) -> None:
         self.switch_view(DeckManagerView, self.config, self.back_to_main_menu)
 
@@ -123,4 +132,4 @@ class GameApp(QMainWindow):
             self.game_logger.close()
             log_path.unlink(missing_ok=True)
             self.game_logger = None
-        self.switch_view(MainMenuView, self.start_sp_game, self.start_mp_game, self.start_cpu_game, self.show_deck_manager, self.show_credits)
+        self.show_main_menu()

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Castle Wars is a strategy game where players build castles and compete against e
 
 - **Gameplay Mechanics** Core gameplay mechanics of the game have been recreated.
 - **Custom Card Decks** Players can customize their card decks and store them in files for later use.
+- **AI Opponents** Multiple AI opponents available, including rule-based and MCTS/neural-network agents.
 
 ## Usage
 

--- a/utils/GameResourcesManager.py
+++ b/utils/GameResourcesManager.py
@@ -16,23 +16,35 @@ class GameResourcesManager:
             return AIPlayer
 
     @staticmethod
-    def load_ai_models() -> list[str]:
-        """Returns a list of all AI model class names that inherit from AIPlayer."""
+    def load_ai_models(progress_callback=None, status_callback=None) -> list[str]:
+        """Returns a list of all AI model class names that inherit from AIPlayer.
+
+        Args:
+            progress_callback: Optional callable receiving an int (0-100) after
+                each file is processed, for use with progress bars.
+            status_callback: Optional callable receiving a status string before
+                each file is imported, for displaying loading messages.
+        """
         ai_models = []
 
         models_dir = Path("models")
-        for file in models_dir.glob("*.py"):
-            module_name = file.stem
-            if module_name.startswith("_"):
-                continue
+        files = [f for f in models_dir.glob("*.py") if not f.stem.startswith("_")]
+        total = len(files)
 
+        for i, file in enumerate(files):
+            module_name = file.stem
+            if status_callback is not None:
+                status_callback(f"Loading {module_name}...")
             try:
                 module = importlib.import_module(f"models.{module_name}")
                 for name, obj in inspect.getmembers(module, inspect.isclass):
                     if issubclass(obj, AIPlayer) and obj is not AIPlayer and obj.__module__ == module.__name__:
                         ai_models.append(name)
             except (ImportError, AttributeError):
-                continue
+                pass
+
+            if progress_callback is not None and total > 0:
+                progress_callback(int((i + 1) * 100 / total))
 
         return sorted(ai_models)
 

--- a/views/MainMenuView.py
+++ b/views/MainMenuView.py
@@ -7,13 +7,14 @@ from views.components.MenuButton import MenuButton
 from utils.GameResourcesManager import GameResourcesManager
 
 class MainMenuView(QFrame):
-    def __init__(self, parent, start_game_sp_callback, start_game_mp_callback, start_game_cpu_callback, display_deck_manager_callback, display_credits_callback=None) -> None:
+    def __init__(self, parent, start_game_sp_callback, start_game_mp_callback, start_game_cpu_callback, display_deck_manager_callback, display_credits_callback=None, ai_models=None) -> None:
         super().__init__(parent)
         self.start_game_sp_callback = start_game_sp_callback
         self.start_game_mp_callback = start_game_mp_callback
         self.start_game_cpu_callback = start_game_cpu_callback
         self.display_deck_manager_callback = display_deck_manager_callback
         self.display_credits_callback = display_credits_callback
+        self._ai_models = ai_models or []
 
         uic.loadUi('views/mainmenu_view.ui', self)
 
@@ -82,7 +83,7 @@ class MainMenuView(QFrame):
         self.menu_button_vbox.addWidget(ai_label)
 
         self.ai_model_combo = QComboBox()
-        ai_models = GameResourcesManager.load_ai_models()
+        ai_models = self._ai_models if self._ai_models else GameResourcesManager.load_ai_models()
         self.ai_model_combo.addItems(ai_models)
         self.menu_button_vbox.addWidget(self.ai_model_combo)
 

--- a/views/SplashScreenView.py
+++ b/views/SplashScreenView.py
@@ -1,0 +1,63 @@
+import resources.resources_ui  # Loads in all resource files into UI
+from PyQt6 import uic
+from PyQt6.QtWidgets import QFrame
+from PyQt6.QtCore import QTimer
+from workers.ResourceLoadWorker import ResourceLoadWorker
+
+class SplashScreenView(QFrame):
+    SMOOTH_TICK_MS = 30
+    SMOOTH_STEP = 1.5  # max progress units per tick (~50 units/sec)
+
+    def __init__(self, parent, done_callback) -> None:
+        super().__init__(parent)
+        self.done_callback = done_callback
+        self._finished = False
+        self._load_complete = False
+        self._loaded_resources = None
+        self._target_progress = 0
+        self._displayed_progress = 0.0
+
+        uic.loadUi("views/splash_screen_view.ui", self)
+
+        self.progress_bar.setRange(0, 100)
+        self.progress_bar.setValue(0)
+
+        self._worker = ResourceLoadWorker()
+        self._worker.progress.connect(self._on_progress)
+        self._worker.status.connect(self.status_label.setText)
+        self._worker.finished.connect(self._on_load_finished)
+        self._worker.start()
+
+        self._smooth_timer = QTimer(self)
+        self._smooth_timer.setInterval(self.SMOOTH_TICK_MS)
+        self._smooth_timer.timeout.connect(self._smooth_tick)
+        self._smooth_timer.start()
+
+    def _on_progress(self, value: int) -> None:
+        self._target_progress = value
+
+    def _smooth_tick(self) -> None:
+        if self._displayed_progress < self._target_progress:
+            self._displayed_progress = min(
+                self._displayed_progress + self.SMOOTH_STEP,
+                float(self._target_progress)
+            )
+            self.progress_bar.setValue(int(self._displayed_progress))
+
+        if self._load_complete and int(self._displayed_progress) >= 100:
+            self.status_label.setText("Ready!")
+            self._finish()
+
+    def _on_load_finished(self, ai_models: list) -> None:
+        self._loaded_resources = ai_models
+        self._load_complete = True
+        self._target_progress = 100
+
+    def _finish(self) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        self._smooth_timer.stop()
+        self._worker.quit()
+        self._worker.wait()
+        self.done_callback(self._loaded_resources)

--- a/views/splash_screen_view.ui
+++ b/views/splash_screen_view.ui
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Frame</class>
+ <widget class="QFrame" name="Frame">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">background-color: rgb(0, 50, 100)</string>
+  </property>
+  <widget class="QLabel" name="splash_title">
+   <property name="geometry">
+    <rect>
+     <x>100</x>
+     <y>200</y>
+     <width>600</width>
+     <height>100</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <family>Gabriola</family>
+     <pointsize>48</pointsize>
+    </font>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">color: white</string>
+   </property>
+   <property name="text">
+    <string>Castle Wars</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="status_label">
+   <property name="geometry">
+    <rect>
+     <x>200</x>
+     <y>330</y>
+     <width>400</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">color: rgba(255, 255, 255, 160); font-size: 11px;</string>
+   </property>
+   <property name="text">
+    <string>Initializing...</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+  </widget>
+  <widget class="QProgressBar" name="progress_bar">
+  <property name="geometry">
+   <rect>
+    <x>200</x>
+    <y>360</y>
+    <width>400</width>
+    <height>25</height>
+   </rect>
+  </property>
+   <property name="styleSheet">
+    <string notr="true">QProgressBar { border: 1px solid white; border-radius: 4px; background-color: rgb(0, 30, 70); }
+QProgressBar::chunk { background-color: rgb(0, 200, 80); border-radius: 3px; }</string>
+   </property>
+   <property name="minimum">
+    <number>0</number>
+   </property>
+   <property name="maximum">
+    <number>100</number>
+   </property>
+   <property name="value">
+    <number>0</number>
+   </property>
+   <property name="textVisible">
+    <bool>false</bool>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/workers/ResourceLoadWorker.py
+++ b/workers/ResourceLoadWorker.py
@@ -1,0 +1,14 @@
+from PyQt6.QtCore import QThread, pyqtSignal
+from utils.GameResourcesManager import GameResourcesManager
+
+class ResourceLoadWorker(QThread):
+    progress = pyqtSignal(int)   # 0-100
+    status = pyqtSignal(str)     # current loading message
+    finished = pyqtSignal(list)  # sorted list of AI model class names
+
+    def run(self):
+        ai_models = GameResourcesManager.load_ai_models(
+            progress_callback=self.progress.emit,
+            status_callback=self.status.emit
+        )
+        self.finished.emit(ai_models)


### PR DESCRIPTION
- Add background thread that preloads AI models at startup
- Add splash screen that transitions to the main menu once loading is complete